### PR TITLE
fix: Removes deprecations

### DIFF
--- a/src/rulr.ts
+++ b/src/rulr.ts
@@ -84,18 +84,12 @@ export { tuple } from './higherOrderRules/tuple/tuple'
 export { union, UnionValidationError } from './higherOrderRules/union/union'
 export {
 	sanitizeBasicAuthFromString,
-	// eslint-disable-next-line deprecation/deprecation
-	isBasicAuthFromString,
 	isBasicAuthAsString,
 	BasicAuthAsString,
 	BasicAuth,
-	// eslint-disable-next-line deprecation/deprecation
-	InvalidBasicAuthFromString,
 	InvalidBasicAuthAsString,
 } from './sanitizationRules/sanitizeBasicAuthFromString/sanitizeBasicAuthFromString'
 export {
-	// eslint-disable-next-line deprecation/deprecation
-	sanitizeBooleanAsString,
 	sanitizeBooleanFromString,
 	isBooleanAsString,
 	BooleanAsString,
@@ -104,16 +98,12 @@ export {
 	falsyBooleanStrings,
 } from './sanitizationRules/sanitizeBooleanFromString/sanitizeBooleanFromString'
 export {
-	// eslint-disable-next-line deprecation/deprecation
-	sanitizeJsonAsString,
 	sanitizeJsonFromString,
 	isJsonAsString,
 	JsonAsString,
 	InvalidJsonAsStringError,
 } from './sanitizationRules/sanitizeJsonFromString/sanitizeJsonFromString'
 export {
-	// eslint-disable-next-line deprecation/deprecation
-	sanitizeNumberAsString,
 	sanitizeNumberFromString,
 	isNumberAsString,
 	NumberAsString,

--- a/src/sanitizationRules/sanitizeBasicAuthFromString/readme.md
+++ b/src/sanitizationRules/sanitizeBasicAuthFromString/readme.md
@@ -4,8 +4,6 @@
 
 This function uses `rulr.isBasicAuthAsString` and can be used when you want to sanitize an input to be basic auth from a string as shown in the example below. This function should only throw `rulr.InvalidBasicAuthAsString`.
 
-Note: `isBasicAuthFromString` and `InvalidBasicAuthFromString` are deprecated, please use `isBasicAuthAsString` and `InvalidBasicAuthAsString` instead.
-
 ```ts
 import * as rulr from 'rulr'
 

--- a/src/sanitizationRules/sanitizeBasicAuthFromString/sanitizeBasicAuthFromString.test.ts
+++ b/src/sanitizationRules/sanitizeBasicAuthFromString/sanitizeBasicAuthFromString.test.ts
@@ -3,8 +3,8 @@ import btoa from 'btoa'
 import { sanitizeBasicAuthFromString, BasicAuth as BasicAuth } from '../../rulr'
 import {
 	BasicAuthAsString,
-	InvalidBasicAuthFromString,
-	isBasicAuthFromString,
+	InvalidBasicAuthAsString,
+	isBasicAuthAsString,
 } from './sanitizeBasicAuthFromString'
 
 test('sanitizeBasicAuthFromString should return key and secret for valid tokens', () => {
@@ -16,41 +16,41 @@ test('sanitizeBasicAuthFromString should return key and secret for valid tokens'
 	assert.ok(output instanceof BasicAuth)
 	assert.strictEqual(output.key, key)
 	assert.strictEqual(output.secret, secret)
-	assert.ok(isBasicAuthFromString(input))
+	assert.ok(isBasicAuthAsString(input))
 	const typeOutput: BasicAuthAsString = input
 	assert.strictEqual(typeOutput, input)
 })
 
 test('sanitizeBasicAuthFromString should now allow value that is not a string', () => {
 	const input = 10
-	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthFromString)
-	assert.strictEqual(isBasicAuthFromString(input), false)
+	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthAsString)
+	assert.strictEqual(isBasicAuthAsString(input), false)
 })
 
 test('sanitizeBasicAuthFromString should now allow value that uses invalid base64 token', () => {
 	const input = 'Basic YTp6-'
-	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthFromString)
-	assert.strictEqual(isBasicAuthFromString(input), false)
+	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthAsString)
+	assert.strictEqual(isBasicAuthAsString(input), false)
 })
 
 test('sanitizeBasicAuthFromString should now allow value that is missing a base64 token', () => {
 	const input = 'Basic '
-	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthFromString)
-	assert.strictEqual(isBasicAuthFromString(input), false)
+	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthAsString)
+	assert.strictEqual(isBasicAuthAsString(input), false)
 })
 
 test('sanitizeBasicAuthFromString should now allow value that is missing a colon separator', () => {
 	const token = btoa('az')
 	const input = `Basic ${token}`
-	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthFromString)
-	assert.strictEqual(isBasicAuthFromString(input), false)
+	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthAsString)
+	assert.strictEqual(isBasicAuthAsString(input), false)
 })
 
 test('sanitizeBasicAuthFromString should now allow value that has too many colon separators', () => {
 	const token = btoa('a:b:c')
 	const input = `Basic ${token}`
-	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthFromString)
-	assert.strictEqual(isBasicAuthFromString(input), false)
+	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthAsString)
+	assert.strictEqual(isBasicAuthAsString(input), false)
 })
 
 test('sanitizeBasicAuthFromString should now allow value that uses incorrect prefix', () => {
@@ -58,6 +58,6 @@ test('sanitizeBasicAuthFromString should now allow value that uses incorrect pre
 	const secret = 'z'
 	const basicAuthToken = `${key}:${secret}`
 	const input = ` Basic${btoa(basicAuthToken)}`
-	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthFromString)
-	assert.strictEqual(isBasicAuthFromString(input), false)
+	assert.throws(() => sanitizeBasicAuthFromString(input), InvalidBasicAuthAsString)
+	assert.strictEqual(isBasicAuthAsString(input), false)
 })

--- a/src/sanitizationRules/sanitizeBasicAuthFromString/sanitizeBasicAuthFromString.ts
+++ b/src/sanitizationRules/sanitizeBasicAuthFromString/sanitizeBasicAuthFromString.ts
@@ -9,11 +9,6 @@ export class InvalidBasicAuthAsString extends BaseError {
 	}
 }
 
-/**
- * @deprecated - Use `InvalidBasicAuthAsString` instead
- **/
-export const InvalidBasicAuthFromString = InvalidBasicAuthAsString
-
 // @TODO - Change to basicAuthAsStringSymbol
 export const basicAuthFromStringSymbol = Symbol()
 
@@ -33,11 +28,6 @@ export function isBasicAuthAsString(input: unknown): input is BasicAuthAsString 
 		decodeBasicAuthValuesFromString(input).length === 2
 	)
 }
-
-/**
- * @deprecated - Use `isBasicAuthAsString` instead
- **/
-export const isBasicAuthFromString = isBasicAuthAsString
 
 export class BasicAuth {
 	constructor(public readonly key: string, public readonly secret: string) {}

--- a/src/sanitizationRules/sanitizeBooleanFromString/readme.md
+++ b/src/sanitizationRules/sanitizeBooleanFromString/readme.md
@@ -4,8 +4,6 @@
 
 This function uses `rulr.isBooleanAsString` and can be used when you want to sanitize an input to be a string containing a boolean as shown in the example below. This function should only throw `rulr.InvalidBooleanAsStringError`.
 
-Note: `sanitizeBooleanAsString` is deprecated, please use `sanitizeBooleanFromString` instead.
-
 ```ts
 import * as rulr from 'rulr'
 

--- a/src/sanitizationRules/sanitizeBooleanFromString/sanitizeBooleanFromString.ts
+++ b/src/sanitizationRules/sanitizeBooleanFromString/sanitizeBooleanFromString.ts
@@ -27,8 +27,3 @@ export function sanitizeBooleanFromString(input: unknown) {
 	}
 	throw new InvalidBooleanAsStringError()
 }
-
-/**
- * @deprecated - Use `sanitizeBooleanFromString` instead
- **/
-export const sanitizeBooleanAsString = sanitizeBooleanFromString

--- a/src/sanitizationRules/sanitizeJsonFromString/readme.md
+++ b/src/sanitizationRules/sanitizeJsonFromString/readme.md
@@ -4,8 +4,6 @@
 
 This function uses `rulr.isJsonAsString` and can be used when you want to sanitize an input to be a string containing JSON as shown in the example below. This function is a higher order rule as it uses a sub-rule to validate input that is JSON. This function should only throw `rulr.InvalidJsonAsStringError`, `SyntaxError`, and errors from the sub-rule.
 
-Note: `sanitizeJsonAsString` is deprecated, please use `sanitizeJsonFromString` instead.
-
 ```ts
 import * as rulr from 'rulr'
 

--- a/src/sanitizationRules/sanitizeJsonFromString/sanitizeJsonFromString.ts
+++ b/src/sanitizationRules/sanitizeJsonFromString/sanitizeJsonFromString.ts
@@ -33,8 +33,3 @@ export function sanitizeJsonFromString<T>(jsonRule: Rule<T>) {
 		throw new InvalidJsonAsStringError()
 	}
 }
-
-/**
- * @deprecated - Use `sanitizeJsonFromString` instead
- **/
-export const sanitizeJsonAsString = sanitizeJsonFromString

--- a/src/sanitizationRules/sanitizeNumberFromString/readme.md
+++ b/src/sanitizationRules/sanitizeNumberFromString/readme.md
@@ -4,8 +4,6 @@
 
 This function uses `rulr.isNumberAsString` and can be used when you want to sanitize an input to be a string containing a number as shown in the example below. This function is a higher order rule as it uses a sub-rule to validate input that is a number. This function should only throw `rulr.InvalidNumberAsStringError` and errors from the sub-rule.
 
-Note: `sanitizeNumberAsString` is deprecated, please use `sanitizeNumberFromString` instead.
-
 ```ts
 import * as rulr from 'rulr'
 

--- a/src/sanitizationRules/sanitizeNumberFromString/sanitizeNumberFromString.ts
+++ b/src/sanitizationRules/sanitizeNumberFromString/sanitizeNumberFromString.ts
@@ -24,8 +24,3 @@ export function sanitizeNumberFromString<T>(numberRule: Rule<T>) {
 		throw new InvalidNumberAsStringError()
 	}
 }
-
-/**
- * @deprecated - Use `sanitizeNumberFromString` instead
- **/
-export const sanitizeNumberAsString = sanitizeNumberFromString


### PR DESCRIPTION
BREAKING CHANGE: Removes support for deprecated Node 16
BREAKING CHANGE: Removes deprecated `isBasicAuthFromString` - instead use `isBasicAuthAsString`
BREAKING CHANGE: Removes deprecated `InvalidBasicAuthFromString` - instead use `InvalidBasicAuthAsString`
BREAKING CHANGE: Removes deprecated `sanitizeBooleanAsString` - instead use `sanitizeBooleanFromString`
BREAKING CHANGE: Removes deprecated `sanitizeJsonAsString` - instead use `sanitizeJsonFromString`
BREAKING CHANGE: Removes deprecated `sanitizeNumberAsString` - instead use `sanitizeNumberFromString`