### PR TITLE
feat: Adds nonEmptyString rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,12 @@ To save you some time, Rulr comes with the following rules.
 - [union](./src/higherOrderRules/union/readme.md)
 - [unknown](./src/valueRules/unknown/readme.md)
 
+### Sized Strings
+
+Since it's quite common to want to restrict the size of strings, Rulr comes with some convenient rules for doing just that.
+
+- [nonEmptyString](./src/sizedStrings/nonEmptyString/readme.md)
+
 ### Constraining Strings
 
 Rulr also comes with a growing list of convenient rules for constraining strings that are mostly built on [Chris O'Hara's extensive and much loved validator package](https://www.npmjs.com/package/validator).

--- a/src/rulr.ts
+++ b/src/rulr.ts
@@ -109,6 +109,12 @@ export {
 	NumberAsString,
 	InvalidNumberAsStringError,
 } from './sanitizationRules/sanitizeNumberFromString/sanitizeNumberFromString'
+export {
+	nonEmptyString,
+	isNonEmptyString,
+	NonEmptyString,
+	InvalidNonEmptyStringError
+} from './sizedStrings/nonEmptyString/nonEmptyString'
 export { any } from './valueRules/any/any'
 export { bigint, isBigInt, InvalidBigIntError } from './valueRules/bigint/bigint'
 export { boolean, isBoolean, InvalidBooleanError } from './valueRules/boolean/boolean'

--- a/src/sizedStrings/nonEmptyString/nonEmptyString.test.ts
+++ b/src/sizedStrings/nonEmptyString/nonEmptyString.test.ts
@@ -1,0 +1,18 @@
+import * as assert from 'assert'
+import { InvalidNonEmptyStringError, NonEmptyString, nonEmptyString } from '../../rulr'
+
+test('nonEmptyString should not allow invalid string input', () => {
+	const input = 0
+	assert.throws(() => nonEmptyString(input), InvalidNonEmptyStringError)
+})
+
+test('nonEmptyString should allow valid non-empty input', () => {
+	const input = 'a'
+	const output: NonEmptyString = nonEmptyString(input)
+	assert.strictEqual(output, input)
+})
+
+test('nonEmptyString should not allow invalid empty input', () => {
+	const input = ''
+	assert.throws(() => nonEmptyString(input), InvalidNonEmptyStringError)
+})

--- a/src/sizedStrings/nonEmptyString/nonEmptyString.ts
+++ b/src/sizedStrings/nonEmptyString/nonEmptyString.ts
@@ -1,0 +1,24 @@
+import { BaseError } from 'make-error'
+import { isString } from '../../valueRules/string/string'
+import { Constrained } from '../../core'
+
+export class InvalidNonEmptyStringError extends BaseError {
+	constructor() {
+		super('expected some characters')
+	}
+}
+
+export const nonEmptyStringSymbol = Symbol()
+
+export type NonEmptyString = Constrained<typeof nonEmptyStringSymbol, string>
+
+export function isNonEmptyString(input: unknown): input is NonEmptyString {
+	return isString(input) && input.length >= 1
+}
+
+export function nonEmptyString(input: unknown) {
+	if (isNonEmptyString(input)) {
+		return input
+	}
+	throw new InvalidNonEmptyStringError()
+}

--- a/src/sizedStrings/nonEmptyString/readme.md
+++ b/src/sizedStrings/nonEmptyString/readme.md
@@ -1,0 +1,35 @@
+# nonEmptyString
+
+[Back to root readme.md](../../../readme.md)
+
+This function uses the `rulr.nonEmptyString` guard to check the input is a valid non-empty string as shown in the example below. It should only throw `rulr.InvalidNonEmptyStringError`.
+
+```ts
+import * as rulr from 'rulr'
+
+const constrainToExample = rulr.object({
+	required: {
+		example: rulr.nonEmptyString,
+	},
+})
+
+type Example = rulr.Static<typeof constrainToExample>
+// {
+//   example: rulr.NonEmptyString
+// }
+
+// Valid
+const example1: Example = constrainToExample({
+	example: 'a',
+})
+
+// Invalid: Not a valid NonEmptyString
+const example2: Example = constrainToExample({
+	example: '',
+})
+
+// Invalid: Not a string
+const example3: Example = constrainToExample({
+	example: 1,
+})
+```


### PR DESCRIPTION
Noticed a clear need for this in https://mwskwong.com/blog/migrating-from-zod-to-valibot-a-comparative-experience

Might be good to have rules for each of the SQL String Data Types in future.