### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   analyse:
     name: Analyse
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/ryasmi/rulr/security/code-scanning/1](https://github.com/ryasmi/rulr/security/code-scanning/1)

The best way to fix this problem is to explicitly set the least privileges required for the workflow job. For CodeQL analysis, the only required permission is usually `contents: read` (read-only access to repository files). This permissions block can be added at the job-level (to the `analyse` job), or at the workflow root (if you want to apply it to all jobs in the workflow). Since there is a single job here, adding at the job-level is suitable.  
To implement this, add the following block under the `analyse:` job headers, just above `runs-on: ubuntu-latest`:

```yaml
permissions:
  contents: read
```

No imports or further definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
